### PR TITLE
Change Webpack build command

### DIFF
--- a/webpack/package.json
+++ b/webpack/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "webpack serve",
-    "build": "webpack -w"
+    "build": "webpack build"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.6",


### PR DESCRIPTION
I'd say that `webpack -w` is rather a watch mode than a build command. This PR suggests to replace it by `webpack build`. This is linked to https://github.com/twbs/bootstrap/issues/37793 and https://github.com/twbs/bootstrap/pull/37796.