### PR TITLE
Fix URL of bootstrap-logo-black.svg

### DIFF
--- a/icons-font/index.html
+++ b/icons-font/index.html
@@ -12,7 +12,7 @@
       <header class="d-flex justify-content-between align-items-md-center pb-3 mb-5 border-bottom">
         <h1 class="h4">
           <a href="/" class="d-flex align-items-center text-dark text-decoration-none">
-            <img class="d-inline-block me-2" width="40" height="32" src="https://raw.githubusercontent.com/twbs/bootstrap/main/site/static/docs/5.2/assets/brand/bootstrap-logo-black.svg" alt="Bootstrap">
+            <img class="d-inline-block me-2" width="40" height="32" src="https://raw.githubusercontent.com/twbs/bootstrap/main/site/static/docs/5.3/assets/brand/bootstrap-logo-black.svg" alt="Bootstrap">
             <span>Icons Font</span>
           </a>
         </h1>

--- a/parcel/src/index.html
+++ b/parcel/src/index.html
@@ -12,7 +12,7 @@
       <header class="d-flex justify-content-between align-items-md-center pb-3 mb-5 border-bottom">
         <h1 class="h4">
           <a href="/" class="d-flex align-items-center text-dark text-decoration-none">
-            <img class="d-inline-block me-2" width="40" height="32" src="https://raw.githubusercontent.com/twbs/bootstrap/main/site/static/docs/5.2/assets/brand/bootstrap-logo-black.svg" alt="Bootstrap">
+            <img class="d-inline-block me-2" width="40" height="32" src="https://raw.githubusercontent.com/twbs/bootstrap/main/site/static/docs/5.3/assets/brand/bootstrap-logo-black.svg" alt="Bootstrap">
             <span>Parcel</span>
           </a>
         </h1>

--- a/sass-js-esm/index.html
+++ b/sass-js-esm/index.html
@@ -12,7 +12,7 @@
       <header class="d-flex justify-content-between align-items-md-center pb-3 mb-5 border-bottom">
         <h1 class="h4">
           <a href="/" class="d-flex align-items-center text-dark text-decoration-none">
-            <img class="d-inline-block me-2" width="40" height="32" src="https://raw.githubusercontent.com/twbs/bootstrap/main/site/static/docs/5.2/assets/brand/bootstrap-logo-black.svg" alt="Bootstrap">
+            <img class="d-inline-block me-2" width="40" height="32" src="https://raw.githubusercontent.com/twbs/bootstrap/main/site/static/docs/5.3/assets/brand/bootstrap-logo-black.svg" alt="Bootstrap">
             <span>Sass &amp; ESM JS</span>
           </a>
         </h1>

--- a/sass-js/index.html
+++ b/sass-js/index.html
@@ -12,7 +12,7 @@
       <header class="d-flex justify-content-between align-items-md-center pb-3 mb-5 border-bottom">
         <h1 class="h4">
           <a href="/" class="d-flex align-items-center text-dark text-decoration-none">
-            <img class="d-inline-block me-2" width="40" height="32" src="https://raw.githubusercontent.com/twbs/bootstrap/main/site/static/docs/5.2/assets/brand/bootstrap-logo-black.svg" alt="Bootstrap">
+            <img class="d-inline-block me-2" width="40" height="32" src="https://raw.githubusercontent.com/twbs/bootstrap/main/site/static/docs/5.3/assets/brand/bootstrap-logo-black.svg" alt="Bootstrap">
             <span>Sass &amp; JS</span>
           </a>
         </h1>

--- a/vite/src/index.html
+++ b/vite/src/index.html
@@ -12,7 +12,7 @@
       <header class="d-flex justify-content-between align-items-md-center pb-3 mb-5 border-bottom">
         <h1 class="h4">
           <a href="/" class="d-flex align-items-center text-dark text-decoration-none">
-            <img class="d-inline-block me-2" width="40" height="32" src="https://raw.githubusercontent.com/twbs/bootstrap/main/site/static/docs/5.2/assets/brand/bootstrap-logo-black.svg" alt="Bootstrap">
+            <img class="d-inline-block me-2" width="40" height="32" src="https://raw.githubusercontent.com/twbs/bootstrap/main/site/static/docs/5.3/assets/brand/bootstrap-logo-black.svg" alt="Bootstrap">
             <span>Vite</span>
           </a>
         </h1>

--- a/vue/src/components/Header.vue
+++ b/vue/src/components/Header.vue
@@ -2,7 +2,7 @@
   <header class="d-flex justify-content-between align-items-md-center pb-3 mb-5 border-bottom">
     <h1 class="h4">
       <a href="/" class="d-flex align-items-center text-dark text-decoration-none">
-        <img class="d-inline-block me-2" width="40" height="32" src="https://raw.githubusercontent.com/twbs/bootstrap/main/site/static/docs/5.2/assets/brand/bootstrap-logo-black.svg" alt="Bootstrap">
+        <img class="d-inline-block me-2" width="40" height="32" src="https://raw.githubusercontent.com/twbs/bootstrap/main/site/static/docs/5.3/assets/brand/bootstrap-logo-black.svg" alt="Bootstrap">
         <span>Vue</span>
       </a>
     </h1>


### PR DESCRIPTION
Since we now have a `5.3` directory instead of `5.2` due to the ongoing Bootstrap alpha version, the logo wasn't no more displayed correctly in some of examples here.

This PR supersedes https://github.com/twbs/examples/pull/31.