### PR TITLE
Bump bootstrap dependencies to use latest popperjs version everywhere

### DIFF
--- a/icons-font/package-lock.json
+++ b/icons-font/package-lock.json
@@ -8,7 +8,7 @@
       "name": "icons-font",
       "version": "0.0.0",
       "dependencies": {
-        "bootstrap": "^5.2.0",
+        "bootstrap": "^5.2.3",
         "bootstrap-icons": "^1.9.1"
       },
       "devDependencies": {
@@ -328,9 +328,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
+      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
       "funding": [
         {
           "type": "github",
@@ -342,7 +342,7 @@
         }
       ],
       "peerDependencies": {
-        "@popperjs/core": "^2.11.5"
+        "@popperjs/core": "^2.11.6"
       }
     },
     "node_modules/bootstrap-icons": {
@@ -4593,9 +4593,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
+      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
       "requires": {}
     },
     "bootstrap-icons": {

--- a/icons-font/package.json
+++ b/icons-font/package.json
@@ -19,7 +19,7 @@
     "test": "npm-run-all css-lint css"
   },
   "dependencies": {
-    "bootstrap": "^5.2.0",
+    "bootstrap": "^5.2.3",
     "bootstrap-icons": "^1.9.1"
   },
   "devDependencies": {

--- a/parcel/package-lock.json
+++ b/parcel/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
-        "bootstrap": "^5.2.0"
+        "bootstrap": "^5.2.3"
       },
       "devDependencies": {
         "@parcel/transformer-sass": "^2.7.0",
@@ -1717,9 +1717,9 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
+      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
       "funding": [
         {
           "type": "github",
@@ -1731,7 +1731,7 @@
         }
       ],
       "peerDependencies": {
-        "@popperjs/core": "^2.11.5"
+        "@popperjs/core": "^2.11.6"
       }
     },
     "node_modules/braces": {
@@ -3969,9 +3969,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
+      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
       "requires": {}
     },
     "braces": {

--- a/parcel/package.json
+++ b/parcel/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.6",
-    "bootstrap": "^5.2.0"
+    "bootstrap": "^5.2.3"
   },
   "devDependencies": {
     "@parcel/transformer-sass": "^2.7.0",

--- a/sass-js-esm/index.html
+++ b/sass-js-esm/index.html
@@ -71,7 +71,7 @@
     <script type="importmap">
     {
       "imports": {
-        "@popperjs/core": "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.2/dist/esm/popper.js",
+        "@popperjs/core": "https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.6/dist/esm/popper.js",
         "bootstrap": "https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.esm.min.js"
       }
     }

--- a/sass-js-esm/package-lock.json
+++ b/sass-js-esm/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
-        "bootstrap": "^5.2.0"
+        "bootstrap": "^5.3.0-alpha1"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.8",
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.3.0-alpha1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.0-alpha1.tgz",
+      "integrity": "sha512-ABZpKK4ObS3kKlIqH+ZVDqoy5t/bhFG0oHTAzByUdon7YIom0lpCeTqRniDzJmbtcWkNe800VVPBiJgxSYTYew==",
       "funding": [
         {
           "type": "github",
@@ -340,7 +340,7 @@
         }
       ],
       "peerDependencies": {
-        "@popperjs/core": "^2.11.5"
+        "@popperjs/core": "^2.11.6"
       }
     },
     "node_modules/boxen": {
@@ -4591,9 +4591,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.3.0-alpha1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.0-alpha1.tgz",
+      "integrity": "sha512-ABZpKK4ObS3kKlIqH+ZVDqoy5t/bhFG0oHTAzByUdon7YIom0lpCeTqRniDzJmbtcWkNe800VVPBiJgxSYTYew==",
       "requires": {}
     },
     "boxen": {

--- a/sass-js/package-lock.json
+++ b/sass-js/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
-        "bootstrap": "^5.2.0"
+        "bootstrap": "^5.2.3"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.8",
@@ -326,9 +326,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
+      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
       "funding": [
         {
           "type": "github",
@@ -340,7 +340,7 @@
         }
       ],
       "peerDependencies": {
-        "@popperjs/core": "^2.11.5"
+        "@popperjs/core": "^2.11.6"
       }
     },
     "node_modules/boxen": {
@@ -4591,9 +4591,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
+      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
       "requires": {}
     },
     "boxen": {

--- a/sass-js/package.json
+++ b/sass-js/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.6",
-    "bootstrap": "^5.2.0"
+    "bootstrap": "^5.2.3"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.8",

--- a/vite/package-lock.json
+++ b/vite/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
-        "bootstrap": "^5.2.0"
+        "bootstrap": "^5.2.3"
       },
       "devDependencies": {
         "sass": "^1.54.8",
@@ -400,9 +400,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
+      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
       "funding": [
         {
           "type": "github",
@@ -414,7 +414,7 @@
         }
       ],
       "peerDependencies": {
-        "@popperjs/core": "^2.11.5"
+        "@popperjs/core": "^2.11.6"
       }
     },
     "node_modules/braces": {
@@ -1000,9 +1000,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
+      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
       "requires": {}
     },
     "braces": {

--- a/vite/package.json
+++ b/vite/package.json
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.6",
-    "bootstrap": "^5.2.0"
+    "bootstrap": "^5.2.3"
   }
 }

--- a/webpack/package-lock.json
+++ b/webpack/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@popperjs/core": "^2.11.6",
-        "bootstrap": "^5.2.0"
+        "bootstrap": "^5.2.3"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.8",
@@ -750,9 +750,9 @@
       }
     },
     "node_modules/bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
+      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
       "funding": [
         {
           "type": "github",
@@ -764,7 +764,7 @@
         }
       ],
       "peerDependencies": {
-        "@popperjs/core": "^2.11.5"
+        "@popperjs/core": "^2.11.6"
       }
     },
     "node_modules/brace-expansion": {
@@ -4666,9 +4666,9 @@
       }
     },
     "bootstrap": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
-      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
+      "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
       "requires": {}
     },
     "brace-expansion": {

--- a/webpack/package.json
+++ b/webpack/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@popperjs/core": "^2.11.6",
-    "bootstrap": "^5.2.0"
+    "bootstrap": "^5.2.3"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.8",


### PR DESCRIPTION
Following https://github.com/twbs/bootstrap/pull/38006#pullrequestreview-1284505139 and https://github.com/twbs/bootstrap/pull/38006#issuecomment-1418550881, this PR modifies all references to popperjs to use the 2.11.6 version instead of the 2.11.2.

Most of the time in this PR, it meant bumping bootstrap dep from 5.2.0 to 5.2.3

**Side note**: Dependabot seems to be enabled in this repo but it doesn't seem to detect deps in sub-directories. I'm wondering if this is configurable 🤔 could be useful for this kind of stuff