### PR TITLE
Specify lockfile-version=2 for older npm compatibility

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+lockfile-version=2

--- a/color-modes/.npmrc
+++ b/color-modes/.npmrc
@@ -1,0 +1,1 @@
+lockfile-version=2

--- a/icons-font/.npmrc
+++ b/icons-font/.npmrc
@@ -1,0 +1,1 @@
+lockfile-version=2

--- a/parcel/.npmrc
+++ b/parcel/.npmrc
@@ -1,0 +1,1 @@
+lockfile-version=2

--- a/sass-js-esm/.npmrc
+++ b/sass-js-esm/.npmrc
@@ -1,0 +1,1 @@
+lockfile-version=2

--- a/sass-js/.npmrc
+++ b/sass-js/.npmrc
@@ -1,0 +1,1 @@
+lockfile-version=2

--- a/starter/.npmrc
+++ b/starter/.npmrc
@@ -1,0 +1,1 @@
+lockfile-version=2

--- a/vite/.npmrc
+++ b/vite/.npmrc
@@ -1,0 +1,1 @@
+lockfile-version=2

--- a/vue/.npmrc
+++ b/vue/.npmrc
@@ -1,0 +1,1 @@
+lockfile-version=2

--- a/webpack/.npmrc
+++ b/webpack/.npmrc
@@ -1,0 +1,1 @@
+lockfile-version=2


### PR DESCRIPTION
Need to check if we need this in each project instead of the root folder