### PR TITLE
CI: specify `cache-dependency-path`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           node-version: "${{ env.NODE }}"
           cache: npm
+          cache-dependency-path: "**/package-lock.json"
 
       - name: Install npm dependencies
         run: npm ci


### PR DESCRIPTION
Unsure if it's needed, but it shouldn't hurt I guess.