### PR TITLE
Change example link to example popover in sass-js

### DIFF
--- a/sass-js/index.html
+++ b/sass-js/index.html
@@ -29,7 +29,7 @@
       </div>
 
       <button type="button" class="btn btn-primary me-3" data-bs-toggle="offcanvas" data-bs-target="#offcanvasExample">Toggle offcanvas</button>
-      <a href="#" class="text-success">Example link</a>
+      <a id="popoverButton" class="text-success" href="#" role="button" data-bs-toggle="popover" title="Custom popover" data-bs-content="This is a Bootstrap popover.">Example popover</a>
 
       <div class="offcanvas offcanvas-end" tabindex="-1" id="offcanvasExample" aria-labelledby="offcanvasExampleLabel">
         <div class="offcanvas-header">

--- a/sass-js/js/main.js
+++ b/sass-js/js/main.js
@@ -8,3 +8,9 @@ import "../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js";
 //
 // Place any custom JS here
 //
+
+// Create an example popover
+document.querySelectorAll('[data-bs-toggle="popover"]')
+  .forEach(popover => {
+    new bootstrap.Popover(popover)
+  })

--- a/sass-js/scss/styles.scss
+++ b/sass-js/scss/styles.scss
@@ -69,7 +69,7 @@ $success: #7952b3;
 // @import "bootstrap/scss/toasts";
 @import "bootstrap/scss/modal"; // Requires transitions
 // @import "bootstrap/scss/tooltip";
-// @import "bootstrap/scss/popover";
+@import "bootstrap/scss/popover";
 // @import "bootstrap/scss/carousel";
 // @import "bootstrap/scss/spinners";
 @import "bootstrap/scss/offcanvas"; // Requires transitions


### PR DESCRIPTION
This PR suggests to update `sass-js` `index.html` to display an 'Example popover' link instead of a simple link mainly for consistency with other examples.