### PR TITLE
Change /build-tools to /contribute

### DIFF
--- a/color-modes/index.html
+++ b/color-modes/index.html
@@ -114,7 +114,7 @@
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/webpack/">Bootstrap Webpack guide</a></li>
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/parcel/">Bootstrap Parcel guide</a></li>
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/vite/">Bootstrap Vite guide</a></li>
-        <li><a href="https://getbootstrap.com/docs/5.3/getting-started/build-tools/">Contributing to Bootstrap</a></li>
+        <li><a href="https://getbootstrap.com/docs/5.3/getting-started/contribute/">Contributing to Bootstrap</a></li>
       </ul>
 
       <hr class="mt-5 mb-4">

--- a/parcel/src/index.html
+++ b/parcel/src/index.html
@@ -62,7 +62,7 @@
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/webpack/">Bootstrap Webpack guide</a></li>
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/parcel/">Bootstrap Parcel guide</a></li>
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/vite/">Bootstrap Vite guide</a></li>
-        <li><a href="https://getbootstrap.com/docs/5.3/getting-started/build-tools/">Contributing to Bootstrap</a></li>
+        <li><a href="https://getbootstrap.com/docs/5.3/getting-started/contribute/">Contributing to Bootstrap</a></li>
       </ul>
 
       <hr class="mt-5 mb-4">

--- a/sass-js-esm/index.html
+++ b/sass-js-esm/index.html
@@ -62,7 +62,7 @@
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/webpack/">Bootstrap Webpack guide</a></li>
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/parcel/">Bootstrap Parcel guide</a></li>
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/vite/">Bootstrap Vite guide</a></li>
-        <li><a href="https://getbootstrap.com/docs/5.3/getting-started/build-tools/">Contributing to Bootstrap</a></li>
+        <li><a href="https://getbootstrap.com/docs/5.3/getting-started/contribute/">Contributing to Bootstrap</a></li>
       </ul>
 
       <hr class="mt-5 mb-4">

--- a/sass-js/index.html
+++ b/sass-js/index.html
@@ -62,7 +62,7 @@
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/webpack/">Bootstrap Webpack guide</a></li>
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/parcel/">Bootstrap Parcel guide</a></li>
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/vite/">Bootstrap Vite guide</a></li>
-        <li><a href="https://getbootstrap.com/docs/5.3/getting-started/build-tools/">Contributing to Bootstrap</a></li>
+        <li><a href="https://getbootstrap.com/docs/5.3/getting-started/contribute/">Contributing to Bootstrap</a></li>
       </ul>
 
       <hr class="mt-5 mb-4">

--- a/vite/src/index.html
+++ b/vite/src/index.html
@@ -62,7 +62,7 @@
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/webpack/">Bootstrap Webpack guide</a></li>
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/parcel/">Bootstrap Parcel guide</a></li>
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/vite/">Bootstrap Vite guide</a></li>
-        <li><a href="https://getbootstrap.com/docs/5.3/getting-started/build-tools/">Contributing to Bootstrap</a></li>
+        <li><a href="https://getbootstrap.com/docs/5.3/getting-started/contribute/">Contributing to Bootstrap</a></li>
       </ul>
 
       <hr class="mt-5 mb-4">

--- a/vue/src/components/AppGuides.vue
+++ b/vue/src/components/AppGuides.vue
@@ -24,7 +24,7 @@ export default {
           title: 'Bootstrap Vite guide'
         },
         { 
-          url: 'https://getbootstrap.com/docs/5.3/getting-started/build-tools/',
+          url: 'https://getbootstrap.com/docs/5.3/getting-started/contribute/',
           title: 'Contributing to Bootstrap'
         },
       ]

--- a/webpack/src/index.html
+++ b/webpack/src/index.html
@@ -60,7 +60,7 @@
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/webpack/">Bootstrap Webpack guide</a></li>
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/parcel/">Bootstrap Parcel guide</a></li>
         <li><a href="https://getbootstrap.com/docs/5.3/getting-started/vite/">Bootstrap Vite guide</a></li>
-        <li><a href="https://getbootstrap.com/docs/5.3/getting-started/build-tools/">Contributing to Bootstrap</a></li>
+        <li><a href="https://getbootstrap.com/docs/5.3/getting-started/contribute/">Contributing to Bootstrap</a></li>
       </ul>
 
       <hr class="mt-5 mb-4">


### PR DESCRIPTION
In our examples, we use /build-tools URL path in some HTML files. In the main Bootstrap repository, /contribute is the real URL, and /build-tools is only an alias.

IMO we should switch to the /contribute URL to ease the maintenance of this repo and avoid useless redirections.