### PR TITLE
Fix postcss plugin options

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -37,7 +37,7 @@ module.exports = {
             loader: 'postcss-loader',
             options: {
               postcssOptions: {
-                plugins: () => [
+                plugins: [
                   autoprefixer
                 ]
               }


### PR DESCRIPTION
I first opened [this PR](https://github.com/twbs/bootstrap/pull/38947), but then I was instructed to open it against the examples repository.

___

The current configuration doesn't work. If you check the output, the vendor prefixes aren't there.

I had to change the syntax a bit. It's a tiny fix.

You can see an example of the correct syntax [here](https://github.com/postcss/autoprefixer/tree/10.4.14#webpack) and [here](https://github.com/webpack-contrib/postcss-loader/tree/v7.3.3#getting-started).