### PR TITLE
Change vite config path import

### DIFF
--- a/vite/vite.config.js
+++ b/vite/vite.config.js
@@ -1,7 +1,7 @@
-const path = require('path')
+import { resolve } from 'path'
 
 export default {
-  root: path.resolve(__dirname, 'src'),
+  root: resolve(__dirname, 'src'),
   build: {
     outDir: '../dist'
   },


### PR DESCRIPTION
### Description

This PR changes the way we import `resolve` from `path` in the Vite config.
This change is suggested to be consistent with the way Vite project imports itself `resolve` in the `vite.config.ts` file in its own documentation (e.g. https://vitejs.dev/guide/build.html#multi-page-app).

It doesn't change anything in the way this example works. You can still run it locally this way:
- `npm run start`
- `npm run build`

### Checklist

- [ ] If this PR is merged, I'll provide a PR in `twbs/bootstrap` to update the documentation accordingly.