### PR TITLE
Finalize the color modes example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Starter](starter/) – CDN links for our CSS and JS
 - [Sass & JS](sass-js/) — Import Sass, Autoprefixer, Stylelint, and our JS bundle via npm
 - [Sass & ESM JS](sass-js-esm/) — Import Sass, Autoprefixer, and Stylelint via npm, and then load our ESM JS with a shim
-- [Color modes](color-modes/) – New example for the Bootstrap v5.3.0 pre-release built on our Sass & ESM JS example. Also includes color mode support and color mode picker.
+- [Color modes](color-modes/) – Color mode support and color mode picker built on our Sass & ESM JS example
 - [Bootstrap Icons font](icons-font/) - Import and compile Sass, Stylelint, PurgeCSS, and our icon font
 - [Parcel](parcel/) - Sass, JS via Parcel
 - [React](react-nextjs/) - Sass with React Bootstrap components using React and Next.js

--- a/color-modes/index.html
+++ b/color-modes/index.html
@@ -76,8 +76,8 @@
 
       <h1>Get started with Bootstrap color modes</h1>
       <div class="col-lg-8 px-0">
-        <p class="fs-4">You've successfully loaded up the Bootstrap Color Modes example! It's loaded up with a pre-release version of <a href="https://getbootstrap.com/">Bootstrap 5.3.0</a>, Sass, <a href="https://github.com/guybedford/es-module-shims">ES Modules Shims</a> for our JavaScript plugins, and our documentation's color mode picker.</p>
-        <p>If this button appears blue and the link appears purple, everything is working. Check out the <strong>Toggle theme</strong> button at the top of the page to switch between color modes. We suggest you review the <a href="https://twbs-bootstrap.netlify.app/docs/5.3/migration/">upcoming migration guide</a>, the <a href="https://twbs-bootstrap.netlify.app/docs/5.3/customize/color/">new color system</a>, and the <a href="https://twbs-bootstrap.netlify.app/docs/5.3/customize/color-modes/">new color modes documentation</a>.</p>
+        <p class="fs-4">You've successfully loaded up the Bootstrap Color Modes example! It's loaded up with <a href="https://getbootstrap.com/">Bootstrap 5</a>, Sass, and <a href="https://github.com/guybedford/es-module-shims">ES Modules Shims</a> for our JavaScript plugins, and our documentation's color mode picker.</p>
+        <p>If this button appears blue and the link appears purple, everything is working. Check out the <strong>Toggle theme</strong> button at the top of the page to switch between color modes.</p>
       </div>
 
       <button type="button" class="btn btn-primary me-3" data-bs-toggle="offcanvas" data-bs-target="#offcanvasExample">Toggle offcanvas</button>


### PR DESCRIPTION
### Description

Our color modes are no longer a pre-release feature and have been available since v5.3.0. This PR suggests getting rid of everything that mentions "v5.3.0 pre-release", "pre-release", "upcoming", etc. to make it more stable from a user perspective like the other examples.