### PR TITLE
Fix Sass imports in Parcel example for Windows

### DIFF
--- a/parcel/src/scss/styles.scss
+++ b/parcel/src/scss/styles.scss
@@ -31,7 +31,7 @@ $enable-shadows: true;
 $offcanvas-box-shadow: 0 1rem 3rem rgba(0, 0, 0, .175);
 
 // Include functions first
-@import "bootstrap/scss/functions";
+@import "~/node_modules/bootstrap/scss/functions";
 
 // Customize some defaults
 $body-color: #333;
@@ -40,49 +40,49 @@ $border-radius: .4rem;
 $success: #7952b3;
 
 // Required
-@import "bootstrap/scss/variables";
-@import "bootstrap/scss/variables-dark";
-@import "bootstrap/scss/maps";
-@import "bootstrap/scss/mixins";
-@import "bootstrap/scss/utilities";
-@import "bootstrap/scss/root";
-@import "bootstrap/scss/reboot";
+@import "~/node_modules/bootstrap/scss/variables";
+@import "~/node_modules/bootstrap/scss/variables-dark";
+@import "~/node_modules/bootstrap/scss/maps";
+@import "~/node_modules/bootstrap/scss/mixins";
+@import "~/node_modules/bootstrap/scss/utilities";
+@import "~/node_modules/bootstrap/scss/root";
+@import "~/node_modules/bootstrap/scss/reboot";
 
-@import "bootstrap/scss/type";
-// @import "bootstrap/scss/images";
-@import "bootstrap/scss/containers";
-@import "bootstrap/scss/grid";
-// @import "bootstrap/scss/tables";
-// @import "bootstrap/scss/forms";
-@import "bootstrap/scss/buttons";
-@import "bootstrap/scss/transitions";
-@import "bootstrap/scss/dropdown";
-// @import "bootstrap/scss/button-group";
-// @import "bootstrap/scss/nav";
-// @import "bootstrap/scss/navbar"; // Requires nav
-// @import "bootstrap/scss/card";
-// @import "bootstrap/scss/breadcrumb";
-// @import "bootstrap/scss/accordion";
-// @import "bootstrap/scss/pagination";
-// @import "bootstrap/scss/badge";
-// @import "bootstrap/scss/alert";
-// @import "bootstrap/scss/progress";
-// @import "bootstrap/scss/list-group";
-@import "bootstrap/scss/close";
-// @import "bootstrap/scss/toasts";
-@import "bootstrap/scss/modal"; // Requires transitions
-// @import "bootstrap/scss/tooltip";
-@import "bootstrap/scss/popover";
-// @import "bootstrap/scss/carousel";
-// @import "bootstrap/scss/spinners";
-@import "bootstrap/scss/offcanvas"; // Requires transitions
-// @import "bootstrap/scss/placeholders";
+@import "~/node_modules/bootstrap/scss/type";
+// @import "~/node_modules/bootstrap/scss/images";
+@import "~/node_modules/bootstrap/scss/containers";
+@import "~/node_modules/bootstrap/scss/grid";
+// @import "~/node_modules/bootstrap/scss/tables";
+// @import "~/node_modules/bootstrap/scss/forms";
+@import "~/node_modules/bootstrap/scss/buttons";
+@import "~/node_modules/bootstrap/scss/transitions";
+@import "~/node_modules/bootstrap/scss/dropdown";
+// @import "~/node_modules/bootstrap/scss/button-group";
+// @import "~/node_modules/bootstrap/scss/nav";
+// @import "~/node_modules/bootstrap/scss/navbar"; // Requires nav
+// @import "~/node_modules/bootstrap/scss/card";
+// @import "~/node_modules/bootstrap/scss/breadcrumb";
+// @import "~/node_modules/bootstrap/scss/accordion";
+// @import "~/node_modules/bootstrap/scss/pagination";
+// @import "~/node_modules/bootstrap/scss/badge";
+// @import "~/node_modules/bootstrap/scss/alert";
+// @import "~/node_modules/bootstrap/scss/progress";
+// @import "~/node_modules/bootstrap/scss/list-group";
+@import "~/node_modules/bootstrap/scss/close";
+// @import "~/node_modules/bootstrap/scss/toasts";
+@import "~/node_modules/bootstrap/scss/modal"; // Requires transitions
+// @import "~/node_modules/bootstrap/scss/tooltip";
+@import "~/node_modules/bootstrap/scss/popover";
+// @import "~/node_modules/bootstrap/scss/carousel";
+// @import "~/node_modules/bootstrap/scss/spinners";
+@import "~/node_modules/bootstrap/scss/offcanvas"; // Requires transitions
+// @import "~/node_modules/bootstrap/scss/placeholders";
 
 // Helpers
-// @import "bootstrap/scss/helpers";
+// @import "~/node_modules/bootstrap/scss/helpers";
 
 // Utilities
-@import "bootstrap/scss/utilities/api";
+@import "~/node_modules/bootstrap/scss/utilities/api";
 
 
 //


### PR DESCRIPTION
Closes #321

### Description

This PR addresses issue #321.

On macOS, there are no problems—everything compiles and launches as expected. However, on Windows, we were able to replicate the issue with @louismaximepiton.

The import statement `@import "bootstrap/scss/bootstrap"` works correctly in our step-by-step guide because it references the `bootstrap.scss` file in the `node_modules` directory. However, when attempting something similar to the Parcel example, such as `@import "bootstrap/scss/functions"`, it fails. This is because Parcel or the Parcel Sass Transformer cannot locate the file named `_functions.scss`.

(it's referenced at several locations—e.g. https://github.com/parcel-bundler/parcel/issues/6002, https://github.com/parcel-bundler/parcel/issues/3704, etc.)

While Sass handles this by default on other systems, it fails to do so with Parcel on Windows for these specific imports.

We considered three potential solutions to fix this issue for Windows users:

1. Use `@import "~/node_modules/bootstrap/scss/functions";`
2. Use `@import "../../node_modules/bootstrap/scss/functions";`
3. Use `@import "~/node_modules/bootstrap/scss/_functions";`

We opted for the simplest approach, which doesn't require users to know the exact filenames (including underscores) or the precise relative paths.

### Upstream Parcel Guide

The [upstream documentation for Parcel](https://getbootstrap.com/docs/5.3/getting-started/parcel/#import-bootstrap) says:

> You can also import our stylesheets individually if you want. [Read our Sass import docs](https://getbootstrap.com/docs/5.3/customize/sass/#importing) for details.

In the link, we use a relative path to target the files, so it'll work as well. I don't think it's needed to modify the upstream guide.