### PR TITLE
Fix: Color Mode Switcher shows wrong icon in auto mode #546

### DIFF
--- a/color-modes/js/color-modes.js
+++ b/color-modes/js/color-modes.js
@@ -8,32 +8,33 @@
   'use strict'
 
   const getStoredTheme = () => localStorage.getItem('theme')
-  const setStoredTheme = theme => localStorage.setItem('theme', theme)
-
-  const getPreferredTheme = () => {
-    const storedTheme = getStoredTheme()
-    if (storedTheme) {
-      return storedTheme
+  const setStoredTheme = theme => {
+    if (theme == null || theme === 'auto') {
+      localStorage.removeItem('theme');
+    } else {
+      localStorage.setItem('theme', theme)
     }
-
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
   }
 
   const setTheme = theme => {
-    if (theme === 'auto') {
+    if (theme == null || theme === 'auto') {
       document.documentElement.setAttribute('data-bs-theme', (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'))
     } else {
       document.documentElement.setAttribute('data-bs-theme', theme)
     }
   }
 
-  setTheme(getPreferredTheme())
+  setTheme(getStoredTheme())
 
   const showActiveTheme = (theme, focus = false) => {
     const themeSwitcher = document.querySelector('#bd-theme')
 
     if (!themeSwitcher) {
       return
+    }
+
+    if (theme == null) {
+      theme = 'auto'
     }
 
     const themeSwitcherText = document.querySelector('#bd-theme-text')
@@ -58,14 +59,14 @@
   }
 
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
-    const storedTheme = getStoredTheme()
-    if (storedTheme !== 'light' && storedTheme !== 'dark') {
-      setTheme(getPreferredTheme())
+    const storedTheme = getStoredTheme();
+    if (storedTheme == null || storedTheme === 'auto') {
+      setTheme(); // react on system theme change only in `auto` mode.
     }
   })
 
   window.addEventListener('DOMContentLoaded', () => {
-    showActiveTheme(getPreferredTheme())
+    showActiveTheme(getStoredTheme())
 
     document.querySelectorAll('[data-bs-theme-value]')
       .forEach(toggle => {


### PR DESCRIPTION
 Root cause (different handling for `null` and `auto` values) contributes to occasional flickering. 