### PR TITLE
Fix color-modes example by loading the JS script at the right moment

### DIFF
--- a/color-modes/index.html
+++ b/color-modes/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="css/styles.css">
-    <script type="module" src="js/color-modes.js"></script>
     <title>Bootstrap Color Modes</title>
   </head>
   <body>
@@ -132,5 +131,6 @@
     }
     </script>
     <script type="module" src="js/main.js"></script>
+    <script type="module" src="js/color-modes.js"></script>
   </body>
 </html>


### PR DESCRIPTION
This PR fixes https://github.com/twbs/examples/issues/571 by moving the `<script>` loading "js/color-modes.js" at the end of the file. On Chrome, this allows to make the color modes dropdown work correctly both locally and via StackBlitz.


Closes https://github.com/twbs/examples/issues/571